### PR TITLE
Add landing page for eventpush.co.uk

### DIFF
--- a/landing/deploy.sh
+++ b/landing/deploy.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+STACK_NAME="eventpush-landing"
+REGION="us-east-1"
+
+echo "=== Deploying landing page infrastructure ==="
+aws cloudformation deploy \
+  --template-file template.yaml \
+  --stack-name $STACK_NAME \
+  --region $REGION \
+  --parameter-overrides \
+    DomainName=eventpush.co.uk \
+    CertificateArn=$1 \
+  --no-fail-on-empty-changeset
+
+echo ""
+echo "=== Getting outputs ==="
+BUCKET=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --region $REGION --query 'Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue' --output text)
+DIST_ID=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --region $REGION --query 'Stacks[0].Outputs[?OutputKey==`CloudFrontDistributionId`].OutputValue' --output text)
+CF_DOMAIN=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --region $REGION --query 'Stacks[0].Outputs[?OutputKey==`CloudFrontDomainName`].OutputValue' --output text)
+
+echo "Bucket: $BUCKET"
+echo "Distribution ID: $DIST_ID"
+echo "CloudFront domain: $CF_DOMAIN"
+
+echo ""
+echo "=== Uploading files ==="
+aws s3 sync . s3://$BUCKET/ \
+  --exclude "template.yaml" \
+  --exclude "deploy.sh" \
+  --exclude ".DS_Store" \
+  --cache-control "public, max-age=3600"
+
+echo ""
+echo "=== Invalidating CloudFront cache ==="
+aws cloudfront create-invalidation --distribution-id $DIST_ID --paths "/*" --output text
+
+echo ""
+echo "=== Done ==="
+echo "Site will be available at: https://eventpush.co.uk"
+echo "CloudFront domain: https://$CF_DOMAIN"
+echo ""
+echo "Point your DNS CNAME for eventpush.co.uk to: $CF_DOMAIN"

--- a/landing/deploy.sh
+++ b/landing/deploy.sh
@@ -1,5 +1,7 @@
-#!/bin/bash
+#!/bin/zsh
 set -e
+
+export DYLD_LIBRARY_PATH="$(brew --prefix expat)/lib:$DYLD_LIBRARY_PATH"
 
 STACK_NAME="eventpush-landing"
 REGION="us-east-1"

--- a/landing/index.html
+++ b/landing/index.html
@@ -1,0 +1,382 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EventPush — Manage your meetups from one place</title>
+  <meta name="description" content="EventPush is a free event management tool for meetup organizers. Create events, schedule LinkedIn posts, message attendees, and sync across platforms — all from one dashboard.">
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚀</text></svg>">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+      color: #1a1a2e;
+      line-height: 1.6;
+      background: #fafafa;
+    }
+
+    a { color: #4361ee; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    /* Header */
+    header {
+      background: #fff;
+      border-bottom: 1px solid #e0e0e0;
+      padding: 1rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .logo { font-size: 1.5rem; font-weight: 700; color: #1a1a2e; }
+    .logo span { color: #4361ee; }
+
+    .header-links a {
+      margin-left: 1.5rem;
+      font-size: 0.95rem;
+      color: #555;
+    }
+
+    .header-links a:hover { color: #4361ee; }
+
+    .cta-btn {
+      display: inline-block;
+      background: #4361ee;
+      color: #fff;
+      padding: 0.6rem 1.5rem;
+      border-radius: 6px;
+      font-weight: 600;
+      font-size: 1rem;
+      transition: background 0.2s;
+    }
+
+    .cta-btn:hover { background: #3451d1; text-decoration: none; }
+
+    /* Hero */
+    .hero {
+      text-align: center;
+      padding: 5rem 2rem 4rem;
+      background: linear-gradient(135deg, #f0f4ff 0%, #fafafa 100%);
+    }
+
+    .hero h1 {
+      font-size: 2.8rem;
+      font-weight: 800;
+      margin-bottom: 1rem;
+      color: #1a1a2e;
+    }
+
+    .hero h1 span { color: #4361ee; }
+
+    .hero p {
+      font-size: 1.25rem;
+      color: #555;
+      max-width: 600px;
+      margin: 0 auto 2rem;
+    }
+
+    .hero-buttons { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+
+    .cta-btn-secondary {
+      display: inline-block;
+      background: #fff;
+      color: #4361ee;
+      padding: 0.6rem 1.5rem;
+      border-radius: 6px;
+      font-weight: 600;
+      font-size: 1rem;
+      border: 2px solid #4361ee;
+      transition: all 0.2s;
+    }
+
+    .cta-btn-secondary:hover { background: #f0f4ff; text-decoration: none; }
+
+    /* Features */
+    .features {
+      padding: 4rem 2rem;
+      max-width: 1000px;
+      margin: 0 auto;
+    }
+
+    .features h2 {
+      text-align: center;
+      font-size: 2rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .features .subtitle {
+      text-align: center;
+      color: #777;
+      margin-bottom: 3rem;
+      font-size: 1.1rem;
+    }
+
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 2rem;
+    }
+
+    .feature-card {
+      background: #fff;
+      border: 1px solid #e8e8e8;
+      border-radius: 10px;
+      padding: 2rem;
+      transition: box-shadow 0.2s;
+    }
+
+    .feature-card:hover { box-shadow: 0 4px 20px rgba(0,0,0,0.08); }
+
+    .feature-card .icon { font-size: 2rem; margin-bottom: 0.75rem; }
+
+    .feature-card h3 {
+      font-size: 1.2rem;
+      margin-bottom: 0.5rem;
+      color: #1a1a2e;
+    }
+
+    .feature-card p { color: #666; font-size: 0.95rem; }
+
+    /* How it works */
+    .how-it-works {
+      background: #fff;
+      padding: 4rem 2rem;
+      border-top: 1px solid #e8e8e8;
+      border-bottom: 1px solid #e8e8e8;
+    }
+
+    .how-it-works h2 {
+      text-align: center;
+      font-size: 2rem;
+      margin-bottom: 2.5rem;
+    }
+
+    .steps {
+      display: flex;
+      justify-content: center;
+      gap: 2rem;
+      flex-wrap: wrap;
+      max-width: 900px;
+      margin: 0 auto;
+    }
+
+    .step {
+      text-align: center;
+      flex: 1;
+      min-width: 200px;
+      max-width: 250px;
+    }
+
+    .step-number {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 48px;
+      height: 48px;
+      background: #4361ee;
+      color: #fff;
+      border-radius: 50%;
+      font-size: 1.3rem;
+      font-weight: 700;
+      margin-bottom: 1rem;
+    }
+
+    .step h3 { font-size: 1.1rem; margin-bottom: 0.5rem; }
+    .step p { color: #666; font-size: 0.9rem; }
+
+    /* Open source */
+    .open-source {
+      text-align: center;
+      padding: 4rem 2rem;
+      max-width: 700px;
+      margin: 0 auto;
+    }
+
+    .open-source h2 { font-size: 2rem; margin-bottom: 1rem; }
+    .open-source p { color: #555; font-size: 1.1rem; margin-bottom: 1.5rem; }
+
+    .tech-badges {
+      display: flex;
+      gap: 0.75rem;
+      justify-content: center;
+      flex-wrap: wrap;
+      margin-top: 1.5rem;
+    }
+
+    .badge {
+      background: #f0f4ff;
+      color: #4361ee;
+      padding: 0.3rem 0.8rem;
+      border-radius: 20px;
+      font-size: 0.85rem;
+      font-weight: 500;
+    }
+
+    /* CTA */
+    .final-cta {
+      text-align: center;
+      padding: 4rem 2rem;
+      background: linear-gradient(135deg, #4361ee 0%, #3451d1 100%);
+      color: #fff;
+    }
+
+    .final-cta h2 { font-size: 2rem; margin-bottom: 0.75rem; }
+    .final-cta p { font-size: 1.1rem; margin-bottom: 2rem; opacity: 0.9; }
+
+    .final-cta .cta-btn {
+      background: #fff;
+      color: #4361ee;
+      padding: 0.8rem 2rem;
+      font-size: 1.1rem;
+    }
+
+    .final-cta .cta-btn:hover { background: #f0f4ff; }
+
+    /* Footer */
+    footer {
+      background: #1a1a2e;
+      color: #aaa;
+      padding: 2.5rem 2rem;
+      text-align: center;
+      font-size: 0.9rem;
+    }
+
+    footer a { color: #8899cc; }
+    footer a:hover { color: #fff; }
+
+    .footer-links {
+      display: flex;
+      gap: 1.5rem;
+      justify-content: center;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+
+    .footer-note {
+      margin-top: 1rem;
+      font-size: 0.8rem;
+      color: #777;
+    }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .hero h1 { font-size: 2rem; }
+      .hero p { font-size: 1.05rem; }
+      header { flex-direction: column; gap: 0.75rem; }
+      .header-links a { margin-left: 0.75rem; }
+    }
+  </style>
+</head>
+<body>
+
+  <header>
+    <div class="logo">Event<span>Push</span></div>
+    <div class="header-links">
+      <a href="#features">Features</a>
+      <a href="#how-it-works">How it works</a>
+      <a href="#open-source">Open source</a>
+      <a href="https://app.eventpush.co.uk" class="cta-btn">Get started</a>
+    </div>
+  </header>
+
+  <section class="hero">
+    <h1>Manage your meetups<br>from <span>one place</span></h1>
+    <p>Create events, schedule LinkedIn posts, message attendees, and sync across platforms — all from a single dashboard. Free for community organizers.</p>
+    <div class="hero-buttons">
+      <a href="https://app.eventpush.co.uk" class="cta-btn">Get started — it's free</a>
+      <a href="https://github.com/jdgoodall1/meetup-organisers-toolkit" class="cta-btn-secondary">View on GitHub</a>
+    </div>
+  </section>
+
+  <section class="features" id="features">
+    <h2>Everything you need to run a meetup</h2>
+    <p class="subtitle">Stop juggling platforms. EventPush handles the busywork.</p>
+    <div class="feature-grid">
+      <div class="feature-card">
+        <div class="icon">📅</div>
+        <h3>Cross-platform events</h3>
+        <p>Create an event once and push it to Meetup.com and LinkedIn. No more copy-pasting between platforms.</p>
+      </div>
+      <div class="feature-card">
+        <div class="icon">📣</div>
+        <h3>Automated LinkedIn posts</h3>
+        <p>Schedule 5 promotional posts per event — at 1 month, 2 weeks, 1 week, 3 days, and day of. Set it and forget it.</p>
+      </div>
+      <div class="feature-card">
+        <div class="icon">💬</div>
+        <h3>Attendee messaging</h3>
+        <p>Send targeted messages to attendees or non-RSVP'd group members. Use templates to save time.</p>
+      </div>
+      <div class="feature-card">
+        <div class="icon">🔄</div>
+        <h3>Event sync</h3>
+        <p>Import existing events from Meetup.com. Stay in sync when events are modified externally.</p>
+      </div>
+      <div class="feature-card">
+        <div class="icon">📝</div>
+        <h3>Draft workflows</h3>
+        <p>Create draft events for review before publishing. Perfect for organizer teams that need approval flows.</p>
+      </div>
+      <div class="feature-card">
+        <div class="icon">🔔</div>
+        <h3>Notifications</h3>
+        <p>Get notified about automated actions, errors, and upcoming events that need your attention.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="how-it-works" id="how-it-works">
+    <h2>How it works</h2>
+    <div class="steps">
+      <div class="step">
+        <div class="step-number">1</div>
+        <h3>Create your event</h3>
+        <p>Fill in the details once in EventPush. Title, description, date, location.</p>
+      </div>
+      <div class="step">
+        <div class="step-number">2</div>
+        <h3>Push to platforms</h3>
+        <p>EventPush creates the event on Meetup.com and LinkedIn automatically.</p>
+      </div>
+      <div class="step">
+        <div class="step-number">3</div>
+        <h3>Automate promotion</h3>
+        <p>Social posts and attendee messages are scheduled and sent for you.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="open-source" id="open-source">
+    <h2>Free and open source</h2>
+    <p>EventPush is built for the community, by the community. The entire codebase is open source. Self-host it yourself or use our hosted version for free.</p>
+    <a href="https://github.com/jdgoodall1/meetup-organisers-toolkit" class="cta-btn-secondary">View on GitHub</a>
+    <div class="tech-badges">
+      <span class="badge">AWS Serverless</span>
+      <span class="badge">React</span>
+      <span class="badge">TypeScript</span>
+      <span class="badge">DynamoDB</span>
+      <span class="badge">Cognito</span>
+      <span class="badge">API Gateway</span>
+    </div>
+  </section>
+
+  <section class="final-cta">
+    <h2>Ready to simplify your meetup management?</h2>
+    <p>Join organizers who spend less time on admin and more time building community.</p>
+    <a href="https://app.eventpush.co.uk" class="cta-btn">Get started — it's free</a>
+  </section>
+
+  <footer>
+    <div class="footer-links">
+      <a href="https://app.eventpush.co.uk">App</a>
+      <a href="https://github.com/jdgoodall1/meetup-organisers-toolkit">GitHub</a>
+      <a href="/privacy.html">Privacy Policy</a>
+      <a href="/terms.html">Terms</a>
+    </div>
+    <p>&copy; 2025 EventPush. Free for community organizers.</p>
+    <p class="footer-note">EventPush uses the Meetup API but is not verified by Meetup.</p>
+  </footer>
+
+</body>
+</html>

--- a/landing/index.html
+++ b/landing/index.html
@@ -371,6 +371,7 @@
     <div class="footer-links">
       <a href="https://app.eventpush.co.uk">App</a>
       <a href="https://github.com/jdgoodall1/meetup-organisers-toolkit">GitHub</a>
+      <a href="https://buymeacoffee.com/jdgoodall1">☕ Buy me a coffee</a>
       <a href="/privacy.html">Privacy Policy</a>
       <a href="/terms.html">Terms</a>
     </div>

--- a/landing/index.html
+++ b/landing/index.html
@@ -375,7 +375,7 @@
       <a href="/privacy.html">Privacy Policy</a>
       <a href="/terms.html">Terms</a>
     </div>
-    <p>&copy; 2025 EventPush. Free for community organizers.</p>
+    <p>&copy; 2026 EventPush. Free for community organizers.</p>
     <p class="footer-note">EventPush uses the Meetup API but is not verified by Meetup.</p>
   </footer>
 

--- a/landing/logo.svg
+++ b/landing/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
+  <rect width="400" height="400" rx="40" fill="#4361ee"/>
+  <text x="200" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="120" font-weight="800" fill="#ffffff">EP</text>
+  <text x="200" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="48" font-weight="600" fill="rgba(255,255,255,0.85)">EventPush</text>
+</svg>

--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -22,7 +22,7 @@
   <div class="container">
     <a href="/" class="back">← Back to EventPush</a>
     <h1>Privacy Policy</h1>
-    <p class="updated">Last updated: May 2025</p>
+    <p class="updated">Last updated: May 2026</p>
 
     <h2>What we collect</h2>
     <p>When you use EventPush, we collect:</p>

--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy — EventPush</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #333; line-height: 1.7; background: #fafafa; }
+    .container { max-width: 700px; margin: 0 auto; padding: 3rem 2rem; }
+    h1 { font-size: 2rem; margin-bottom: 0.5rem; color: #1a1a2e; }
+    .updated { color: #777; margin-bottom: 2rem; font-size: 0.9rem; }
+    h2 { font-size: 1.3rem; margin-top: 2rem; margin-bottom: 0.75rem; color: #1a1a2e; }
+    p, ul { margin-bottom: 1rem; }
+    ul { padding-left: 1.5rem; }
+    li { margin-bottom: 0.5rem; }
+    a { color: #4361ee; }
+    .back { display: inline-block; margin-bottom: 2rem; color: #4361ee; font-size: 0.95rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <a href="/" class="back">← Back to EventPush</a>
+    <h1>Privacy Policy</h1>
+    <p class="updated">Last updated: May 2025</p>
+
+    <h2>What we collect</h2>
+    <p>When you use EventPush, we collect:</p>
+    <ul>
+      <li><strong>Account information:</strong> Your email address and name, provided during signup via AWS Cognito.</li>
+      <li><strong>Platform credentials:</strong> OAuth tokens for Meetup.com and LinkedIn, stored encrypted. We never see your passwords for those services.</li>
+      <li><strong>Event data:</strong> Events you create, scheduled posts, messages, and notification preferences.</li>
+    </ul>
+
+    <h2>How we use your data</h2>
+    <p>We use your data solely to provide the EventPush service:</p>
+    <ul>
+      <li>Creating and managing events on Meetup.com and LinkedIn on your behalf</li>
+      <li>Scheduling and publishing social media posts</li>
+      <li>Sending messages to event attendees and group members</li>
+      <li>Sending you notifications about your events and automated actions</li>
+    </ul>
+    <p>We do not sell, rent, or share your personal data with third parties for marketing purposes.</p>
+
+    <h2>Third-party services</h2>
+    <p>EventPush integrates with:</p>
+    <ul>
+      <li><strong>AWS (Amazon Web Services):</strong> Hosting, authentication (Cognito), database (DynamoDB). Subject to the <a href="https://aws.amazon.com/privacy/">AWS Privacy Policy</a>.</li>
+      <li><strong>Meetup.com:</strong> Event creation and management via their API. Subject to <a href="https://www.meetup.com/privacy/">Meetup's Privacy Policy</a>.</li>
+      <li><strong>LinkedIn:</strong> Event and post creation via their API. Subject to <a href="https://www.linkedin.com/legal/privacy-policy">LinkedIn's Privacy Policy</a>.</li>
+    </ul>
+
+    <h2>Data storage and security</h2>
+    <p>Your data is stored in AWS DynamoDB in the us-east-1 region. OAuth tokens are stored encrypted. All data is transmitted over HTTPS. We follow AWS security best practices for access control.</p>
+
+    <h2>Data retention</h2>
+    <p>We retain your data for as long as your account is active. If you delete your account, we will delete your personal data within 30 days. Event data that has been published to external platforms (Meetup.com, LinkedIn) is governed by those platforms' policies.</p>
+
+    <h2>Your rights</h2>
+    <p>You can:</p>
+    <ul>
+      <li>Access your data through the EventPush dashboard</li>
+      <li>Update your profile and notification preferences at any time</li>
+      <li>Request deletion of your account and data by contacting us</li>
+      <li>Disconnect your Meetup.com or LinkedIn accounts at any time</li>
+    </ul>
+
+    <h2>Cookies</h2>
+    <p>EventPush uses only essential cookies for authentication session management. We do not use tracking cookies or analytics.</p>
+
+    <h2>Changes to this policy</h2>
+    <p>We may update this privacy policy from time to time. We will notify you of significant changes via the app or email.</p>
+
+    <h2>Contact</h2>
+    <p>For privacy-related questions, contact us via the <a href="https://github.com/jdgoodall1/meetup-organisers-toolkit/issues">GitHub issues page</a>.</p>
+  </div>
+</body>
+</html>

--- a/landing/template.yaml
+++ b/landing/template.yaml
@@ -1,0 +1,91 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: EventPush Landing Page - S3 + CloudFront static site
+
+Parameters:
+  DomainName:
+    Type: String
+    Default: eventpush.co.uk
+    Description: Custom domain name for the landing page
+  CertificateArn:
+    Type: String
+    Description: ACM certificate ARN for the custom domain (must be in us-east-1 for CloudFront)
+
+Resources:
+  LandingBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ${DomainName}-landing
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  LandingBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref LandingBucket
+      PolicyDocument:
+        Statement:
+          - Sid: AllowCloudFrontOAC
+            Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action: s3:GetObject
+            Resource: !Sub ${LandingBucket.Arn}/*
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistribution}
+
+  OriginAccessControl:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Name: !Sub ${DomainName}-oac
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
+
+  CloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        DefaultRootObject: index.html
+        Aliases:
+          - !Ref DomainName
+        ViewerCertificate:
+          AcmCertificateArn: !Ref CertificateArn
+          SslSupportMethod: sni-only
+          MinimumProtocolVersion: TLSv1.2_2021
+        Origins:
+          - Id: S3Origin
+            DomainName: !GetAtt LandingBucket.RegionalDomainName
+            OriginAccessControlId: !Ref OriginAccessControl
+            S3OriginConfig:
+              OriginAccessIdentity: ''
+        DefaultCacheBehavior:
+          TargetOriginId: S3Origin
+          ViewerProtocolPolicy: redirect-to-https
+          CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6  # CachingOptimized
+          Compress: true
+        CustomErrorResponses:
+          - ErrorCode: 404
+            ResponseCode: 404
+            ResponsePagePath: /index.html
+            ErrorCachingMinTTL: 10
+        HttpVersion: http2and3
+        PriceClass: PriceClass_100
+
+Outputs:
+  CloudFrontDomainName:
+    Description: CloudFront distribution domain name
+    Value: !GetAtt CloudFrontDistribution.DomainName
+
+  CloudFrontDistributionId:
+    Description: CloudFront distribution ID (for cache invalidation)
+    Value: !Ref CloudFrontDistribution
+
+  BucketName:
+    Description: S3 bucket name for uploading landing page files
+    Value: !Ref LandingBucket

--- a/landing/terms.html
+++ b/landing/terms.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Use — EventPush</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #333; line-height: 1.7; background: #fafafa; }
+    .container { max-width: 700px; margin: 0 auto; padding: 3rem 2rem; }
+    h1 { font-size: 2rem; margin-bottom: 0.5rem; color: #1a1a2e; }
+    .updated { color: #777; margin-bottom: 2rem; font-size: 0.9rem; }
+    h2 { font-size: 1.3rem; margin-top: 2rem; margin-bottom: 0.75rem; color: #1a1a2e; }
+    p, ul { margin-bottom: 1rem; }
+    ul { padding-left: 1.5rem; }
+    li { margin-bottom: 0.5rem; }
+    a { color: #4361ee; }
+    .back { display: inline-block; margin-bottom: 2rem; color: #4361ee; font-size: 0.95rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <a href="/" class="back">← Back to EventPush</a>
+    <h1>Terms of Use</h1>
+    <p class="updated">Last updated: May 2025</p>
+
+    <h2>1. Acceptance</h2>
+    <p>By using EventPush, you agree to these terms. If you don't agree, don't use the service.</p>
+
+    <h2>2. The service</h2>
+    <p>EventPush is a free event management tool that helps meetup organizers create events, schedule social media posts, and manage attendee communications across platforms including Meetup.com and LinkedIn.</p>
+
+    <h2>3. Your account</h2>
+    <p>You are responsible for maintaining the security of your account credentials. You must provide accurate information when creating your account. You must be at least 18 years old to use EventPush.</p>
+
+    <h2>4. Acceptable use</h2>
+    <p>You agree to:</p>
+    <ul>
+      <li>Use EventPush only for managing legitimate events and community groups</li>
+      <li>Not use the service to send spam or unsolicited messages</li>
+      <li>Comply with the terms of service of any connected platforms (Meetup.com, LinkedIn)</li>
+      <li>Not attempt to access other users' accounts or data</li>
+      <li>Not use the service for any illegal purpose</li>
+    </ul>
+
+    <h2>5. Third-party platforms</h2>
+    <p>EventPush connects to third-party services (Meetup.com, LinkedIn) on your behalf. Your use of those platforms is governed by their respective terms of service. EventPush is not responsible for actions taken by those platforms.</p>
+
+    <h2>6. Data and content</h2>
+    <p>You retain ownership of all content you create through EventPush. By using the service, you grant us permission to store and transmit your content as necessary to provide the service. See our <a href="/privacy.html">Privacy Policy</a> for details on data handling.</p>
+
+    <h2>7. Service availability</h2>
+    <p>EventPush is provided "as is" without warranty. We make reasonable efforts to keep the service available but do not guarantee uptime. We may modify or discontinue the service at any time.</p>
+
+    <h2>8. Limitation of liability</h2>
+    <p>To the fullest extent permitted by law, EventPush and its contributors shall not be liable for any indirect, incidental, or consequential damages arising from your use of the service.</p>
+
+    <h2>9. Open source</h2>
+    <p>EventPush is open source software. The source code is available on <a href="https://github.com/jdgoodall1/meetup-organisers-toolkit">GitHub</a> under its respective license. These terms apply to the hosted version of the service at eventpush.co.uk.</p>
+
+    <h2>10. Changes</h2>
+    <p>We may update these terms from time to time. Continued use of the service after changes constitutes acceptance of the updated terms.</p>
+
+    <h2>11. Contact</h2>
+    <p>For questions about these terms, contact us via the <a href="https://github.com/jdgoodall1/meetup-organisers-toolkit/issues">GitHub issues page</a>.</p>
+  </div>
+</body>
+</html>

--- a/landing/terms.html
+++ b/landing/terms.html
@@ -22,7 +22,7 @@
   <div class="container">
     <a href="/" class="back">← Back to EventPush</a>
     <h1>Terms of Use</h1>
-    <p class="updated">Last updated: May 2025</p>
+    <p class="updated">Last updated: May 2026</p>
 
     <h2>1. Acceptance</h2>
     <p>By using EventPush, you agree to these terms. If you don't agree, don't use the service.</p>


### PR DESCRIPTION
Static landing page for `eventpush.co.uk` — needed before submitting Meetup.com and LinkedIn OAuth applications.

## Files
- `landing/index.html` — main landing page with hero, features, how it works, open source section, CTA
- `landing/privacy.html` — privacy policy (required by Meetup API license terms)
- `landing/terms.html` — terms of use

## Hosting
Deploy to S3 + CloudFront, GitHub Pages, or a second Amplify app pointed at `eventpush.co.uk`. The main app will live at `app.eventpush.co.uk`.

## Notes
- Pure HTML/CSS, no framework, no build step
- Includes required Meetup API disclaimer: "EventPush uses the Meetup API but is not verified by Meetup"
- Privacy policy meets Meetup's requirement of being "at least as protective" as theirs
- Mobile responsive

Closes #9