### PR TITLE
Configure LinkedIn OAuth credentials

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,3 +5,7 @@ VITE_USER_POOL_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxx
 # API Configuration
 VITE_API_ENDPOINT=https://api.example.com/dev
 VITE_AWS_REGION=us-east-1
+
+
+# LinkedIn OAuth Configuration
+VITE_LINKEDIN_CLIENT_ID=your-linkedin-client-id

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -2,3 +2,5 @@ VITE_USER_POOL_ID=us-east-1_nOh2A8d2I
 VITE_USER_POOL_CLIENT_ID=237nrnp12ofo8kvb4i50tra6s8
 VITE_API_ENDPOINT=https://jgjs95gl55.execute-api.us-east-1.amazonaws.com/dev
 VITE_AWS_REGION=us-east-1
+
+VITE_LINKEDIN_CLIENT_ID=78w4gzdnyvv0ut

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,7 +56,7 @@ const AppContent: React.FC = () => {
         } 
       />
       <Route 
-        path="/linkedin/callback" 
+        path="/auth/linkedin/callback" 
         element={<LinkedInCallback />} 
       />
       <Route 

--- a/frontend/src/components/LinkedInAuth.tsx
+++ b/frontend/src/components/LinkedInAuth.tsx
@@ -49,9 +49,9 @@ const LinkedInAuth: React.FC<LinkedInAuthProps> = ({ onAuthSuccess, onAuthError 
     setError(null);
     
     // LinkedIn OAuth URL - this would typically be configured in environment variables
-    const clientId = process.env.VITE_LINKEDIN_CLIENT_ID || 'your-linkedin-client-id';
-    const redirectUri = encodeURIComponent(`${window.location.origin}/linkedin/callback`);
-    const scope = encodeURIComponent('r_liteprofile r_emailaddress w_member_social rw_organization_admin');
+    const clientId = import.meta.env.VITE_LINKEDIN_CLIENT_ID || '78w4gzdnyvv0ut';
+    const redirectUri = encodeURIComponent(`${window.location.origin}/auth/linkedin/callback`);
+    const scope = encodeURIComponent('openid profile email w_member_social');
     const state = Math.random().toString(36).substring(7); // Simple state for CSRF protection
     
     // Store state in sessionStorage for verification

--- a/template.yaml
+++ b/template.yaml
@@ -20,6 +20,9 @@ Globals:
         USER_POOL_CLIENT_ID: !Ref UserPoolClient
         SCHEDULER_QUEUE_URL: !Ref SchedulerQueue
         REGION: !Ref AWS::Region
+        LINKEDIN_CLIENT_ID: !Ref LinkedInClientId
+        LINKEDIN_CLIENT_SECRET: !Ref LinkedInClientSecret
+        LINKEDIN_REDIRECT_URI: !Ref LinkedInRedirectUri
 
 Parameters:
   Environment:
@@ -27,6 +30,19 @@ Parameters:
     Default: dev
     AllowedValues: [dev, staging, prod]
     Description: Environment name
+  LinkedInClientId:
+    Type: String
+    Default: '78w4gzdnyvv0ut'
+    Description: LinkedIn OAuth Client ID
+  LinkedInClientSecret:
+    Type: String
+    NoEcho: true
+    Default: ''
+    Description: LinkedIn OAuth Client Secret
+  LinkedInRedirectUri:
+    Type: String
+    Default: 'https://app.eventpush.co.uk/auth/linkedin/callback'
+    Description: LinkedIn OAuth Redirect URI
 
 Resources:
   # Cognito User Pool


### PR DESCRIPTION
Configures real LinkedIn OAuth credentials for the EventPush app.

## Changes
- `frontend/src/components/LinkedInAuth.tsx` — Updated client ID to real value, fixed redirect URI path to `/auth/linkedin/callback`, updated OAuth scopes to `openid profile email w_member_social`, switched from `process.env` to `import.meta.env`
- `frontend/src/App.tsx` — Fixed callback route from `/linkedin/callback` to `/auth/linkedin/callback` to match the redirect URI registered with LinkedIn
- `frontend/.env.production` — Added `VITE_LINKEDIN_CLIENT_ID`
- `frontend/.env.example` — Added LinkedIn config placeholder
- `template.yaml` — Added `LinkedInClientId`, `LinkedInClientSecret`, `LinkedInRedirectUri` parameters and environment variables for all Lambda functions

## Deployment notes
When deploying the backend, pass the LinkedIn client secret:
```bash
sam deploy --parameter-overrides LinkedInClientSecret=YOUR_SECRET_HERE
```

The client secret should NOT be committed to the repo.

Closes #3